### PR TITLE
stop duplicating payload in the body of the event

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -20,7 +20,7 @@ pub fn auth(uri: &Uri, payload: &str) -> Result<String, Error> {
             Tag::new(&["method", "POST"]),
             Tag::new(&["payload", &payload_hash]),
         ],
-        content: payload.to_owned(),
+        content: "",
     };
     let event = signer.sign_event(pre_event)?;
     let event_string = serde_json::to_string(&event)?;


### PR DESCRIPTION
Sorry, I edited this file on GitHub so it's probably broken, but I don't know if this is correct. Are you taking the same content sent in the body of the POST and putting it inside the event which is then base64d and sent as a header? This feels wrong, I think we can get away with just the hash of the content, no?

Also, maybe we should remove the URL and method from the tags because they're completely irrelevant (I know NIP-98 mentions them, but still we gain nothing by following that).