### PR TITLE
fix `&str` -> `String`

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -20,7 +20,7 @@ pub fn auth(uri: &Uri, payload: &str) -> Result<String, Error> {
             Tag::new(&["method", "POST"]),
             Tag::new(&["payload", &payload_hash]),
         ],
-        content: "",
+        content: "".to_string(),
     };
     let event = signer.sign_event(pre_event)?;
     let event_string = serde_json::to_string(&event)?;


### PR DESCRIPTION
I knew this was broken. Sorry.